### PR TITLE
set default value for uninformative filter to True

### DIFF
--- a/mavis.wdl
+++ b/mavis.wdl
@@ -181,7 +181,7 @@ task runMavis {
     Int mavisMemoryLimit = 32000
     Int minClusterPerFile = 10
     String drawNonSynonymousCdnaOnly = "False"
-    String mavisUninformativeFilter = "False"
+    String mavisUninformativeFilter = "True"
     String modules
     Int jobMemory = 12
     Int sleepInterval = 20


### PR DESCRIPTION
this had been set to False in the current version, but True in older version.
Analysis is being run with an ini that overrides this to True

i want to set the default as True, and have that associated with the tagged version of this workflow