### PR TITLE
modifications to correct how we can specify clusters/batch size for p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [3.3.3] - 2026-04-16
+### Fixed
+- [GRD-1113]https://jira.oicr.on.ca/browse/GRD-1113
+-  runMavis task has an argument, 'Int minClusterPerFile = 10', which did not propogate properly to allow it to be implemented.   
+-  argument is now split to minClusterPerFileWG and Int minClusterPerFileWT, with changes to allow it to properly limit to size of the clusters/batches in the WG and WT sections
+
 ## [3.3.2] - 2025-06-13
 ### Fixed
 - Fixed an issue where the file paths were not updated correctly due to a missing update during deployment 3.3.0.

--- a/mavis.wdl
+++ b/mavis.wdl
@@ -192,7 +192,9 @@ task runMavis {
     Int mavisTransValidationMemory = 32000
     Int mavisMemoryLimit = 32000
     String mavisQueue = "u20.q"
-    Int minClusterPerFile = 10
+    #Int minClusterPerFile = 10
+    Int minClusterPerFileWG = 10
+    Int minClusterPerFileWT = 10
     String drawNonSynonymousCdnaOnly = "False"
     String mavisUninformativeFilter = "True"
     String modules
@@ -229,7 +231,8 @@ task runMavis {
     mavisTransValidationMemory: "Memory allocated for transvalidation step"
     mavisMemoryLimit: "Max Memory allocated for MAVIS"
     mavisQueue: "the mavis job queue"
-    minClusterPerFile: "Determines the way parallel calculations are organized "
+    minClusterPerFileWG: "Parellization control by limiting cluster size "
+    minClusterPerFileWT: "Parellization control by limiting cluster size "
     drawNonSynonymousCdnaOnly: "flag for MAVIS visualization control"
     mavisUninformativeFilter: "Should be enabled if used is only interested in events inside genes, speeds up calculations"
     modules: "modules needed to run MAVIS"
@@ -307,10 +310,39 @@ task runMavis {
     ./~{scriptName} &
     wait
     
+
+    
+    ##################
+    ## post setup adjustment to handle a failure, not sure why this was needed
+    ## it adjusts the bins value then tries to run it again
     if [ ! -f ~{outputCONFIG} ]; then
       sed -i 's/_bins 500/_bins ~{maxBins}/' ~{scriptName}
       ./~{scriptName}
     fi
+    ##################
+    
+    
+    ##################
+    ## post setup adjustment to inject the cluster size into the cfg file
+    ## it is not clear how to do this with mavis setup
+    cp mavis_config.cfg mavis_config.cfg.original
+    WTblock=`grep -n "\[WT" mavis_config.cfg | cut -d: -f1`
+    if [ $WTblock>0 ]
+    then
+      n=$((WTblock+4))
+      sed -i "${n}i min_clusters_per_file = ~{minClusterPerFileWT} " mavis_config.cfg
+    fi
+
+    WGblock=`grep -n "\[WG" mavis_config.cfg | cut -d: -f1`
+    if [ $WGblock>0 ]
+    then
+      n=$((WGblock+4))
+      sed -i "${n}i min_clusters_per_file = ~{minClusterPerFileWG} " mavis_config.cfg
+    fi
+    ################
+    
+    
+    
 
     export MAVIS_ALIGNER='~{mavisAligner}'
     export MAVIS_SCHEDULER=~{mavisScheduler}
@@ -320,10 +352,12 @@ task runMavis {
     export MAVIS_TRANS_VALIDATION_MEMORY=~{mavisTransValidationMemory}
     export MAVIS_MEMORY_LIMIT=~{mavisMemoryLimit}
     export DRAW_NON_SYNONYMOUS_CDNA_ONLY=~{drawNonSynonymousCdnaOnly}
-    export min_clusters_per_file=~{minClusterPerFile}
     export MAVIS_UNINFORMATIVE_FILTER=~{mavisUninformativeFilter}
     export MAVIS_QUEUE=~{mavisQueue}
     mavis setup ~{outputCONFIG} -o .
+    
+    
+    
     BATCHID=$(grep MS_batch build.cfg | grep -v \] | sed s/.*-// | tail -n 1)
     mavis schedule -o . --submit 2> >(tee launch_stderr.log)
     sleep ~{sleepInterval}

--- a/mavis.wdl
+++ b/mavis.wdl
@@ -192,7 +192,6 @@ task runMavis {
     Int mavisTransValidationMemory = 32000
     Int mavisMemoryLimit = 32000
     String mavisQueue = "u20.q"
-    #Int minClusterPerFile = 10
     Int minClusterPerFileWG = 10
     Int minClusterPerFileWT = 10
     String drawNonSynonymousCdnaOnly = "False"


### PR DESCRIPTION
…arellalization

briefly
the runMavis task generates a setup file, which is runs
mavis config
to generate a mavis_setup.cfg file

this file is then run through 
mavis setup mavis_setup.cfg
to produce the required directory structure, and it will cluster events into batches with a default maximum batch size of 50

the intent is to allow this default to be adjusted, using a workflow default of 10 (or allowing the user to specify by passing the task argument to the workflow)

mavis_setup.cfg
needs to include a parameter
min_clusters_per_file
In the sections concerning the WG or the WT analysis.

I am unable to see a way to propagate this down when the .cfg file is created by 'mavis config'

so instead
i) let mavis_setup.cfg be created as it has been
ii) some code to modify this file, before running 'mavis setup', to include the parameter

